### PR TITLE
Make distconv a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "wandb>=0.19.6",
   "open3d>=0.18.0",
   "PyYAML>=6.0.2",
+  "distconv @ git+https://github.com/LBANN/DistConv.git",
 ]
 requires-python = ">=3.9"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ wandb>=0.19.6
 open3d>=0.18.0
 PyYAML>=6.0.2
 mpi4py==4.0.2 --no-binary mpi4py
+distconv @ git+https://github.com/LBANN/DistConv.git
 
 # cuda
 #     torch==2.7.1+cu126

--- a/scripts/install-matrix.sh
+++ b/scripts/install-matrix.sh
@@ -1,5 +1,4 @@
 ml load python/3.11.5 && python3 -m venv .venvs/scaffoldvenv-matrix && source .venvs/scaffoldvenv-matrix/bin/activate && pip install --upgrade pip
 ml cuda/12.6.0 gcc/12.1.1 mvapich2/2.3.7
 export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
-git clone git@github.com:LBANN/DistConv.git
-pip install --no-binary=mpi4py -e .[cuda] DistConv/ --prefix=.venvs/scaffoldvenv-matrix --extra-index-url https://download.pytorch.org/whl/cu126 2>&1 | tee install.log
+pip install --no-binary=mpi4py -e .[cuda] --prefix=.venvs/scaffoldvenv-matrix --extra-index-url https://download.pytorch.org/whl/cu126 2>&1 | tee install.log

--- a/scripts/install-tuolumne.sh
+++ b/scripts/install-tuolumne.sh
@@ -1,4 +1,3 @@
 ml load python/3.11.5 && python3 -m venv .venvs/scaffoldvenv-tuo && source .venvs/scaffoldvenv-tuo/bin/activate && pip install --upgrade pip
 ml load rocm/6.4.2 rccl/fast-env-slows-mpi libfabric
-git clone git@github.com:LBANN/DistConv.git
-pip install -e .[rocmwci] DistConv/ --prefix=.venvs/scaffoldvenv-tuo 2>&1 | tee install.log
+pip install -e .[rocmwci] --prefix=.venvs/scaffoldvenv-tuo 2>&1 | tee install.log


### PR DESCRIPTION
- [x] Here's how we specify the public https://github.com/LBANN/DistConv repo as a dependency of ScaFFold. It would be even simpler if it was a pypi package `distconv@VER`, but not required.