### PR TITLE
Fix model size mismatch on restart

### DIFF
--- a/ScaFFold/cli.py
+++ b/ScaFFold/cli.py
@@ -179,15 +179,21 @@ def main():
 
         # Recalculate unet_layers to capture any CLI overrides
         combined_config["unet_layers"] = (
-            combined_config["problem_scale"] - combined_config["unet_bottleneck_dim"] + 1
+            combined_config["problem_scale"]
+            - combined_config["unet_bottleneck_dim"]
+            + 1
         )
 
         # Resolve paths to absolute, matching Config() behavior
         if "base_run_dir" in combined_config and combined_config["base_run_dir"]:
-            combined_config["base_run_dir"] = str(Path(combined_config["base_run_dir"]).resolve())
-        
+            combined_config["base_run_dir"] = str(
+                Path(combined_config["base_run_dir"]).resolve()
+            )
+
         if "dataset_dir" in combined_config and combined_config["dataset_dir"]:
-            combined_config["dataset_dir"] = str(Path(combined_config["dataset_dir"]).resolve())
+            combined_config["dataset_dir"] = str(
+                Path(combined_config["dataset_dir"]).resolve()
+            )
 
         # Calculate these variables after override
         combined_config["vol_size"] = pow(2, combined_config["problem_scale"])


### PR DESCRIPTION
When we create a config object, we calculate `unet_layers` from `problem_scale`. In the CLI we allow for overriding `problem_scale`, but we never updated `unet_layers` when this happened. This was causing a mismatch in the size of the model across restarts. We now correctly update `unet_layers` in the CLI. I also made sure we fully resolve paths in the CLI to match the behavior in Config.

Tested by kicking off a new run with problem_scale=7 set via CLI arg, killed it after a few epochs, and restarted successfully.

Closes #8 