### PR TITLE
Add `num-shards` and `epochs` to cli

### DIFF
--- a/ScaFFold/cli.py
+++ b/ScaFFold/cli.py
@@ -161,6 +161,11 @@ def main():
         type=int,
         help="DistConv param: number of shards to divide the tensor into. It's best to choose the fewest ranks needed to fit one sample in GPU memory, since that keeps communication at a minimum",
     )
+    benchmark_parser.add_argument(
+        "--epochs",
+        type=int,
+        help="Number of training epochs.",
+    )
 
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()


### PR DESCRIPTION
Since we need to vary `num-shards` with `problem-scale` (which is already in the cli), it makes it easier to sweep multiple parameter configs if `num-shards` is also a cli parameter.