### PR TITLE
remove unet bottleneck dim from dataset params used to generate unique hash ID

### DIFF
--- a/ScaFFold/datagen/get_dataset.py
+++ b/ScaFFold/datagen/get_dataset.py
@@ -33,7 +33,6 @@ INCLUDE_KEYS = [
     "n_categories",
     "n_instances_used_per_fractal",
     "problem_scale",
-    "unet_bottleneck_dim",
     "seed",
     "variance_threshold",
     "n_fracts_per_vol",


### PR DESCRIPTION
Quick PR to remove the unet bottleneck dim from dataset hash ID. Unet bottleneck dim does not impact aspects of the dataset in anyway, so it should not be used to help identify unique datasets.