### PR TITLE
remove unet bottleneck dim from dataset params used to generate unique dataset hash

### DIFF
--- a/ScaFFold/datagen/get_dataset.py
+++ b/ScaFFold/datagen/get_dataset.py
@@ -33,7 +33,6 @@ INCLUDE_KEYS = [
     "n_categories",
     "n_instances_used_per_fractal",
     "problem_scale",
-    "unet_bottleneck_dim",
     "seed",
     "variance_threshold",
     "n_fracts_per_vol",


### PR DESCRIPTION
The parameters we hash to create a unique dataset ID should really only be those that actually affect the dataset in some way. We currently include `unet_bottleneck_dim` in this set, but it does not impact the dataset at all. This PR removes that param from the hashing.