### PR TITLE
Accurately report finish criteria

### DIFF
--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -241,10 +241,14 @@ def main(kwargs_dict: dict = {}):
     total_train_time = train_data["epoch_duration"].sum()
     epochs = np.atleast_1d(train_data["epoch"])
     total_epochs = int(epochs[-1])
-    log.info(
-        f"Benchmark run at scale {config.problem_scale} complete. \n\
-        Trained to >= 0.95 validation dice score in {total_train_time:.2f} seconds, {total_epochs} epochs."
-    )
+    if config.epochs == -1:
+        extra_msg = f"Trained to >= {config.target_dice} validation dice score in {total_train_time:.2f} seconds, {total_epochs} epochs."
+    else:
+        extra_msg = (
+            f"Completed in {total_train_time:.2f} seconds, {total_epochs} epochs."
+        )
+
+    log.info(f"Benchmark run at scale {config.problem_scale} complete. \n{extra_msg}")
 
     #
     # Generate plots


### PR DESCRIPTION
- [x] closes #19 
- [x] Only report "trained to" dice score if we are testing convergence, and report correct dice score instead of hardcoded value