### PR TITLE
Warmup evaluation step

### DIFF
--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -481,6 +481,22 @@ class PyTorchTrainer(BaseTrainer):
         self.optimizer.zero_grad(set_to_none=True)
 
         if self.config.dist:
+            self.val_loader.sampler.set_epoch(0)
+
+        self.log.info("Running evaluation warmup")
+        evaluate(
+            self.model,
+            self.val_loader,
+            self.device,
+            self.config.torch_amp,
+            self.world_rank == 0,
+            self.criterion,
+            self.config.n_categories,
+            self.config._parallel_strategy,
+        )
+        self.model.train()
+
+        if self.config.dist:
             torch.distributed.barrier()
         self.log.info(f"Done warmup. Took {int(time.time() - start_warmup)}s")
 

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -483,7 +483,6 @@ class PyTorchTrainer(BaseTrainer):
         if self.config.dist:
             self.val_loader.sampler.set_epoch(0)
 
-        self.log.info("Running evaluation warmup")
         evaluate(
             self.model,
             self.val_loader,
@@ -694,7 +693,7 @@ class PyTorchTrainer(BaseTrainer):
                     self.val_loader,
                     self.device,
                     self.config.torch_amp,
-                    True if self.world_rank == 0 else False,
+                    self.world_rank == 0,
                     self.criterion,
                     self.config.n_categories,
                     self.config._parallel_strategy,


### PR DESCRIPTION
Addresses #41 

Fixes an issue where the evaluate step at the end of epoch 1 takes longer than every other epoch, because that code path is not tested beforehand. This PR calls `evaluate` during warmup.