### PR TITLE
Fix `inf` val loss in early epochs

### DIFF
--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -94,7 +94,12 @@ def evaluate(
                 continue
 
             # --- 1. Sharded CE Loss ---
-            local_ce_sum = F.cross_entropy(local_preds, local_labels, reduction="sum")
+            with torch.autocast(
+                device.type if device.type != "mps" else "cpu", enabled=False
+            ):
+                local_ce_sum = F.cross_entropy(
+                    local_preds.float(), local_labels, reduction="sum"
+                )
             global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
 
             # Divide by total global voxels to get the mean CE Loss

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -410,9 +410,13 @@ class PyTorchTrainer(BaseTrainer):
                 )
 
                 # 1. Sharded Cross Entropy
-                local_ce_sum = F.cross_entropy(
-                    local_preds, local_labels, reduction="sum"
-                )
+                with torch.autocast(
+                    self.device.type if self.device.type != "mps" else "cpu",
+                    enabled=False,
+                ):
+                    local_ce_sum = F.cross_entropy(
+                        local_preds.float(), local_labels, reduction="sum"
+                    )
 
                 # Pass the spatial_mesh directly
                 global_ce_sum = SpatialAllReduce.apply(local_ce_sum, self.spatial_mesh)
@@ -598,9 +602,15 @@ class PyTorchTrainer(BaseTrainer):
                             )
 
                             # 1. Sharded Cross Entropy
-                            local_ce_sum = F.cross_entropy(
-                                local_preds, local_labels, reduction="sum"
-                            )
+                            with torch.autocast(
+                                self.device.type if self.device.type != "mps" else "cpu",
+                                enabled=False,
+                            ):
+                                local_ce_sum = F.cross_entropy(
+                                    local_preds.float(),
+                                    local_labels,
+                                    reduction="sum",
+                                )
 
                             # Pass the spatial_mesh directly
                             global_ce_sum = SpatialAllReduce.apply(

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -603,7 +603,9 @@ class PyTorchTrainer(BaseTrainer):
 
                             # 1. Sharded Cross Entropy
                             with torch.autocast(
-                                self.device.type if self.device.type != "mps" else "cpu",
+                                self.device.type
+                                if self.device.type != "mps"
+                                else "cpu",
                                 enabled=False,
                             ):
                                 local_ce_sum = F.cross_entropy(


### PR DESCRIPTION
We've seen that early epochs have `inf` val_loss_epoch and val_loss_avg. This was caused by the validation CE loss being accumulated in AMP precision -- the local CE sum over samples at scale 7+ overflows in float16.

This PR disables AMP for the local CE calculation, preventing the f16 cast and subsequent overflow.