### PR TITLE
Move to sharded data loading

### DIFF
--- a/ScaFFold/utils/data_loading.py
+++ b/ScaFFold/utils/data_loading.py
@@ -13,9 +13,11 @@
 # SPDX-License-Identifier: (Apache-2.0)
 
 import pickle
+from dataclasses import dataclass
 from os import listdir
 from os.path import isfile, join, splitext
 from pathlib import Path
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -30,13 +32,91 @@ LEGACY_DATASET_FORMAT_VERSION = 1
 META_FILENAME = "meta.yaml"
 
 
+@dataclass(frozen=True)
+class SpatialShardSpec:
+    """Describe the local spatial shard owned by the current rank."""
+
+    shard_dims: Tuple[int, ...]
+    num_shards: Tuple[int, ...]
+    shard_indices: Tuple[int, ...]
+
+    def __post_init__(self):
+        if not (
+            len(self.shard_dims)
+            == len(self.num_shards)
+            == len(self.shard_indices)
+        ):
+            raise ValueError(
+                "shard_dims, num_shards, and shard_indices must have matching lengths"
+            )
+        if len(set(self.shard_dims)) != len(self.shard_dims):
+            raise ValueError(f"Shard dimensions must be unique: {self.shard_dims}")
+        for shard_dim, num_shards, shard_index in zip(
+            self.shard_dims, self.num_shards, self.shard_indices
+        ):
+            if shard_dim < 2:
+                raise ValueError(
+                    f"Invalid shard_dim {shard_dim}: only spatial dimensions are supported"
+                )
+            if num_shards < 1:
+                raise ValueError(
+                    f"Invalid num_shards {num_shards} for shard_dim {shard_dim}"
+                )
+            if shard_index < 0 or shard_index >= num_shards:
+                raise ValueError(
+                    f"Invalid shard_index {shard_index} for shard_dim {shard_dim} with {num_shards} shards"
+                )
+
+    @staticmethod
+    def _chunk_slice(size: int, num_shards: int, shard_index: int) -> slice:
+        """Match torch.chunk-style uneven shard boundaries."""
+
+        chunk_size = (size + num_shards - 1) // num_shards
+        start = shard_index * chunk_size
+        if start >= size:
+            raise ValueError(
+                f"Empty local shard: dim size {size}, num_shards {num_shards}, shard_index {shard_index}"
+            )
+        stop = min(size, start + chunk_size)
+        return slice(start, stop)
+
+    def slice_array(
+        self, array: np.ndarray, axis_map: Dict[int, int], array_label: str
+    ) -> np.ndarray:
+        if not self.shard_dims:
+            return array
+
+        slices = [slice(None)] * array.ndim
+        for shard_dim, num_shards, shard_index in zip(
+            self.shard_dims, self.num_shards, self.shard_indices
+        ):
+            if shard_dim not in axis_map:
+                raise ValueError(
+                    f"No axis mapping defined for {array_label} shard_dim {shard_dim}"
+                )
+            axis = axis_map[shard_dim]
+            if axis >= array.ndim:
+                raise ValueError(
+                    f"Axis {axis} out of range for {array_label} with shape {array.shape}"
+                )
+            slices[axis] = self._chunk_slice(array.shape[axis], num_shards, shard_index)
+
+        return array[tuple(slices)]
+
+
 class BasicDataset(Dataset):
     def __init__(
-        self, images_dir: str, mask_dir: str, mask_suffix: str = "", data_dir: str = ""
+        self,
+        images_dir: str,
+        mask_dir: str,
+        mask_suffix: str = "",
+        data_dir: str = "",
+        spatial_shard_spec: Optional[SpatialShardSpec] = None,
     ):
         self.images_dir = Path(images_dir)
         self.mask_dir = Path(mask_dir)
         self.mask_suffix = mask_suffix
+        self.spatial_shard_spec = spatial_shard_spec
         self.dataset_root = self.images_dir.parents[1]
         self.dataset_format_version = self._load_dataset_format_version()
 
@@ -63,9 +143,8 @@ class BasicDataset(Dataset):
         return len(self.ids)
 
     @staticmethod
-    def _load_numpy_array(path):
-        with open(path, "rb") as handle:
-            return np.load(handle)
+    def _load_numpy_array(path, mmap_mode=None):
+        return np.load(path, allow_pickle=False, mmap_mode=mmap_mode)
 
     def _load_dataset_format_version(self):
         meta_path = self.dataset_root / META_FILENAME
@@ -108,6 +187,23 @@ class BasicDataset(Dataset):
     def _prepare_optimized_mask(mask):
         return np.ascontiguousarray(mask, dtype=MASK_DTYPE)
 
+    def _slice_image_array(self, img):
+        if self.spatial_shard_spec is None:
+            return img
+
+        if self.dataset_format_version >= DATASET_FORMAT_VERSION:
+            axis_map = {2: 1, 3: 2, 4: 3}
+        else:
+            axis_map = {2: 0, 3: 1, 4: 2}
+        return self.spatial_shard_spec.slice_array(img, axis_map, "image")
+
+    def _slice_mask_array(self, mask):
+        if self.spatial_shard_spec is None:
+            return mask
+
+        axis_map = {2: 0, 3: 1, 4: 2}
+        return self.spatial_shard_spec.slice_array(mask, axis_map, "mask")
+
     def __getitem__(self, idx):
         name = self.ids[idx]
         mask_file = list(self.mask_dir.glob(name + self.mask_suffix + ".*"))
@@ -119,8 +215,13 @@ class BasicDataset(Dataset):
         assert len(mask_file) == 1, (
             f"Either no mask or multiple masks found for the ID {name}: {mask_file}"
         )
-        mask = self._load_numpy_array(mask_file[0])
-        img = self._load_numpy_array(img_file[0])
+        mmap_mode = "r" if self.spatial_shard_spec is not None else None
+        # Memmap lets each rank slice out just its local shard without eagerly
+        # reading the full sample into process memory first.
+        mask = self._load_numpy_array(mask_file[0], mmap_mode=mmap_mode)
+        img = self._load_numpy_array(img_file[0], mmap_mode=mmap_mode)
+        mask = self._slice_mask_array(mask)
+        img = self._slice_image_array(img)
 
         if self.dataset_format_version >= DATASET_FORMAT_VERSION:
             img = self._prepare_optimized_image(img)
@@ -136,5 +237,17 @@ class BasicDataset(Dataset):
 
 
 class FractalDataset(BasicDataset):
-    def __init__(self, images_dir, mask_dir, data_dir):
-        super().__init__(images_dir, mask_dir, mask_suffix="_mask", data_dir=data_dir)
+    def __init__(
+        self,
+        images_dir,
+        mask_dir,
+        data_dir,
+        spatial_shard_spec: Optional[SpatialShardSpec] = None,
+    ):
+        super().__init__(
+            images_dir,
+            mask_dir,
+            mask_suffix="_mask",
+            data_dir=data_dir,
+            spatial_shard_spec=spatial_shard_spec,
+        )

--- a/ScaFFold/utils/data_loading.py
+++ b/ScaFFold/utils/data_loading.py
@@ -181,11 +181,11 @@ class BasicDataset(Dataset):
 
     @staticmethod
     def _prepare_optimized_image(img):
-        return np.ascontiguousarray(img, dtype=VOLUME_DTYPE)
+        return np.array(img, dtype=VOLUME_DTYPE, copy=True, order="C")
 
     @staticmethod
     def _prepare_optimized_mask(mask):
-        return np.ascontiguousarray(mask, dtype=MASK_DTYPE)
+        return np.array(mask, dtype=MASK_DTYPE, copy=True, order="C")
 
     def _slice_image_array(self, img):
         if self.spatial_shard_spec is None:

--- a/ScaFFold/utils/data_loading.py
+++ b/ScaFFold/utils/data_loading.py
@@ -42,9 +42,7 @@ class SpatialShardSpec:
 
     def __post_init__(self):
         if not (
-            len(self.shard_dims)
-            == len(self.num_shards)
-            == len(self.shard_indices)
+            len(self.shard_dims) == len(self.num_shards) == len(self.shard_indices)
         ):
             raise ValueError(
                 "shard_dims, num_shards, and shard_indices must have matching lengths"

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -12,12 +12,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0)
 
-import math
-
 import torch
 import torch.nn.functional as F
 from distconv import DCTensor
-from torch.distributed.tensor import DTensor, Replicate, Shard
 from tqdm import tqdm
 
 from ScaFFold.utils.dice_score import (
@@ -66,20 +63,9 @@ def evaluate(
             # Dummy channel dimension [B, 1, D, H, W]
             mask_true = mask_true.unsqueeze(1)
 
-            # DDP Sharding
-            ddp_placements = [Shard(0)] + [Replicate()] * len(
-                parallel_strategy.shard_dim
-            )
-            image_dp = DTensor.from_local(
-                image, parallel_strategy.device_mesh, placements=ddp_placements
-            ).to_local()
-            mask_true_dp = DTensor.from_local(
-                mask_true, parallel_strategy.device_mesh, placements=ddp_placements
-            ).to_local()
-
-            # DistConv Spatial Sharding
-            dcx = DCTensor.distribute(image_dp, parallel_strategy)
-            mask_true_dc = DCTensor.distribute(mask_true_dp, parallel_strategy)
+            # Inputs are already loaded as local shards by the dataset.
+            dcx = DCTensor.from_shard(image, parallel_strategy)
+            mask_true_dc = DCTensor.from_shard(mask_true, parallel_strategy)
 
             # Forward pass on sharded data
             dcy = net(dcx)
@@ -102,9 +88,10 @@ def evaluate(
                 )
             global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
 
-            # Divide by total global voxels to get the mean CE Loss
-            global_total_voxels = local_labels.numel() * math.prod(
-                parallel_strategy.num_shards
+            # Divide by the actual global voxel count to handle uneven shards.
+            local_voxel_count = local_ce_sum.new_tensor(float(local_labels.numel()))
+            global_total_voxels = SpatialAllReduce.apply(
+                local_voxel_count, spatial_mesh
             )
             CE_loss = global_ce_sum / global_total_voxels
 

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -89,7 +89,11 @@ def evaluate(
             global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
 
             # Divide by the actual global voxel count to handle uneven shards.
-            local_voxel_count = local_ce_sum.new_tensor(float(local_labels.numel()))
+            local_voxel_count = torch.tensor(
+                float(local_labels.numel()),
+                device=local_labels.device,
+                dtype=torch.float32,
+            )
             global_total_voxels = SpatialAllReduce.apply(
                 local_voxel_count, spatial_mesh
             )

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -432,8 +432,10 @@ class PyTorchTrainer(BaseTrainer):
                 # Pass the spatial_mesh directly
                 global_ce_sum = SpatialAllReduce.apply(local_ce_sum, self.spatial_mesh)
 
-                local_voxel_count = local_ce_sum.new_tensor(
-                    float(local_labels.numel())
+                local_voxel_count = torch.tensor(
+                    float(local_labels.numel()),
+                    device=local_labels.device,
+                    dtype=torch.float32,
                 )
                 global_total_voxels = SpatialAllReduce.apply(
                     local_voxel_count, self.spatial_mesh
@@ -635,8 +637,10 @@ class PyTorchTrainer(BaseTrainer):
                                 local_ce_sum, self.spatial_mesh
                             )
 
-                            local_voxel_count = local_ce_sum.new_tensor(
-                                float(local_labels.numel())
+                            local_voxel_count = torch.tensor(
+                                float(local_labels.numel()),
+                                device=local_labels.device,
+                                dtype=torch.float32,
                             )
                             global_total_voxels = SpatialAllReduce.apply(
                                 local_voxel_count, self.spatial_mesh

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -12,8 +12,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0)
 
-# Standard library
-import math
 import os
 import shutil
 import time
@@ -25,12 +23,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 from distconv import DCTensor
 from torch import optim
-from torch.distributed.tensor import DTensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from ScaFFold.utils.checkpointing import CheckpointManager
-from ScaFFold.utils.data_loading import FractalDataset
+from ScaFFold.utils.data_loading import FractalDataset, SpatialShardSpec
 from ScaFFold.utils.dice_score import SpatialAllReduce, compute_sharded_dice
 from ScaFFold.utils.distributed import get_local_rank, get_world_rank, get_world_size
 
@@ -69,9 +66,14 @@ class BaseTrainer:
         self.criterion = None
         self.global_step = 0
         self.start_epoch = -1
-        self.ps = None  # DistConv ParallelStrategy
+        self.ps = getattr(self.config, "_parallel_strategy", None)
         self.spatial_mesh = None  # Spatial mesh for use w/ DistConv
-        self.ddp_placements = None  # DDP placements for use w/ DistConv
+        self.data_num_replicas = self.world_size
+        self.data_replica_rank = self.world_rank
+        if self.ps is not None:
+            self.spatial_mesh = self.ps.device_mesh[self.ps.distconv_dim_names]
+            self.data_num_replicas = self.ps.ddp_ranks
+            self.data_replica_rank = self.ps.ddp_ind
 
         self.checkpoint_path_absolute = str(
             self.config.run_dir + "/" + self.config.checkpoint_dir
@@ -98,12 +100,25 @@ class BaseTrainer:
         val_mask_dir = dataset_dir / "masks/validation"
         train_unique_masks_path = dataset_dir / "train_unique_mask_vals"
         val_unique_masks_path = dataset_dir / "val_unique_mask_vals"
+        spatial_shard_spec = None
+        if self.ps is not None:
+            spatial_shard_spec = SpatialShardSpec(
+                shard_dims=tuple(self.ps.shard_dim),
+                num_shards=tuple(self.ps.num_shards),
+                shard_indices=tuple(self.ps.shard_ind),
+            )
 
         self.train_set = FractalDataset(
-            train_vol_dir, train_mask_dir, data_dir=train_unique_masks_path
+            train_vol_dir,
+            train_mask_dir,
+            data_dir=train_unique_masks_path,
+            spatial_shard_spec=spatial_shard_spec,
         )
         self.val_set = FractalDataset(
-            val_vol_dir, val_mask_dir, data_dir=val_unique_masks_path
+            val_vol_dir,
+            val_mask_dir,
+            data_dir=val_unique_masks_path,
+            spatial_shard_spec=spatial_shard_spec,
         )
         self.n_train = len(self.train_set)
         self.n_val = len(self.val_set)
@@ -115,10 +130,15 @@ class BaseTrainer:
         """Create DistributedSamplers for train and validation datasets."""
         if self.config.dist:
             self.train_sampler = torch.utils.data.distributed.DistributedSampler(
-                self.train_set
+                self.train_set,
+                num_replicas=self.data_num_replicas,
+                rank=self.data_replica_rank,
             )
             self.val_sampler = torch.utils.data.distributed.DistributedSampler(
-                self.val_set, shuffle=False
+                self.val_set,
+                num_replicas=self.data_num_replicas,
+                rank=self.data_replica_rank,
+                shuffle=False,
             )
         else:
             self.train_sampler = torch.utils.data.RandomSampler(self.train_set)
@@ -366,18 +386,9 @@ class PyTorchTrainer(BaseTrainer):
             # Add a dummy channel dimension to get 5D [B, 1, D, H, W]
             true_masks = true_masks.unsqueeze(1)
 
-            # Data parallel sharding
-            images_dp = DTensor.from_local(
-                images, self.ps.device_mesh, placements=self.ddp_placements
-            ).to_local()
-
-            true_masks_dp = DTensor.from_local(
-                true_masks, self.ps.device_mesh, placements=self.ddp_placements
-            ).to_local()
-
-            # Spatial sharding via DistConv
-            images_dc = DCTensor.distribute(images_dp, self.ps)
-            true_masks_dc = DCTensor.distribute(true_masks_dp, self.ps)
+            # Inputs are already loaded as local shards by the dataset.
+            images_dc = DCTensor.from_shard(images, self.ps)
+            true_masks_dc = DCTensor.from_shard(true_masks, self.ps)
             self._get_memsize(images_dc, "Sharded image", self.config.verbose)
 
             with torch.autocast(
@@ -421,8 +432,11 @@ class PyTorchTrainer(BaseTrainer):
                 # Pass the spatial_mesh directly
                 global_ce_sum = SpatialAllReduce.apply(local_ce_sum, self.spatial_mesh)
 
-                global_total_voxels = local_labels.numel() * math.prod(
-                    self.config.dc_num_shards
+                local_voxel_count = local_ce_sum.new_tensor(
+                    float(local_labels.numel())
+                )
+                global_total_voxels = SpatialAllReduce.apply(
+                    local_voxel_count, self.spatial_mesh
                 )
                 loss_ce = global_ce_sum / global_total_voxels
 
@@ -462,7 +476,7 @@ class PyTorchTrainer(BaseTrainer):
                 local_preds_softmax,
                 local_labels_one_hot,
             )
-            del loss_ce, loss_dice, loss, images_dp, true_masks_dp
+            del loss_ce, loss_dice, loss
 
             if self.world_rank == 0:
                 peak_alloc = torch.cuda.max_memory_allocated() / (1024**3)
@@ -533,7 +547,7 @@ class PyTorchTrainer(BaseTrainer):
                     else f"{epoch}/{self.config.epochs}"
                 )
                 with tqdm(
-                    total=self.n_train // self.world_size,
+                    total=len(self.train_sampler),
                     desc=f"({os.path.basename(self.config.run_dir)}) \
                             Epoch {estr}",
                     unit="img",
@@ -560,23 +574,10 @@ class PyTorchTrainer(BaseTrainer):
                         # Add a dummy channel dimension to get 5D [B, 1, D, H, W]
                         true_masks = true_masks.unsqueeze(1)
 
-                        # Data parallel sharding
-                        images_dp = DTensor.from_local(
-                            images, self.ps.device_mesh, placements=self.ddp_placements
-                        ).to_local()
-
-                        true_masks_dp = DTensor.from_local(
-                            true_masks,
-                            self.ps.device_mesh,
-                            placements=self.ddp_placements,
-                        ).to_local()
-
-                        # Delete source tensors immediately after use to keep memory down
+                        # Inputs are already loaded as local shards by the dataset.
+                        images_dc = DCTensor.from_shard(images, self.ps)
+                        true_masks_dc = DCTensor.from_shard(true_masks, self.ps)
                         del images, true_masks
-
-                        # Spatial sharding via DistConv
-                        images_dc = DCTensor.distribute(images_dp, self.ps)
-                        true_masks_dc = DCTensor.distribute(true_masks_dp, self.ps)
                         self._get_memsize(
                             images_dc, "Sharded image", self.config.verbose
                         )
@@ -634,8 +635,11 @@ class PyTorchTrainer(BaseTrainer):
                                 local_ce_sum, self.spatial_mesh
                             )
 
-                            global_total_voxels = local_labels.numel() * math.prod(
-                                self.config.dc_num_shards
+                            local_voxel_count = local_ce_sum.new_tensor(
+                                float(local_labels.numel())
+                            )
+                            global_total_voxels = SpatialAllReduce.apply(
+                                local_voxel_count, self.spatial_mesh
                             )
                             loss_ce = global_ce_sum / global_total_voxels
 

--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -25,7 +25,6 @@ import torch
 import torch.distributed as dist
 import yaml
 from distconv import DistConvDDP, ParallelStrategy
-from torch.distributed.tensor import Replicate, Shard
 
 from ScaFFold.datagen.get_dataset import get_dataset
 from ScaFFold.unet import UNet

--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -23,8 +23,10 @@ import numpy as np
 import psutil
 import torch
 import torch.distributed as dist
+from torch.distributed.tensor import Replicate, Shard
 import yaml
 from distconv import DistConvDDP, ParallelStrategy
+
 
 from ScaFFold.datagen.get_dataset import get_dataset
 from ScaFFold.unet import UNet

--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -23,10 +23,9 @@ import numpy as np
 import psutil
 import torch
 import torch.distributed as dist
-from torch.distributed.tensor import Replicate, Shard
 import yaml
 from distconv import DistConvDDP, ParallelStrategy
-
+from torch.distributed.tensor import Replicate, Shard
 
 from ScaFFold.datagen.get_dataset import get_dataset
 from ScaFFold.unet import UNet


### PR DESCRIPTION
This PR makes changes to the data loading so that individual GPUs only load their own shards of data, rather than loading full samples and then sharding. This should help reduce memory requirements at higher problem scales.