### PR TITLE
Exit if dice score is NaN

### DIFF
--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -778,4 +778,8 @@ class PyTorchTrainer(BaseTrainer):
                 dice_score_train = val_score
                 epoch += 1
 
+                # This check must exist otherwise the condition dice_score_train < self.config.target_dice will evaluate to False and incorrectly exit the training
+                if math.isnan(dice_score_train):
+                    raise ValueError("Invalid value (NaN) encountered in dice score computation")
+
         adiak_value("final_epochs", epoch)

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -780,6 +780,8 @@ class PyTorchTrainer(BaseTrainer):
 
                 # This check must exist otherwise the condition dice_score_train < self.config.target_dice will evaluate to False and incorrectly exit the training
                 if math.isnan(dice_score_train):
-                    raise ValueError("Invalid value (NaN) encountered in dice score computation")
+                    raise ValueError(
+                        "Invalid value (NaN) encountered in dice score computation"
+                    )
 
         adiak_value("final_epochs", epoch)


### PR DESCRIPTION
On `main`, the training will falsely report that it converged if the validation dice score is `nan`. This state is unrecoverable without a checkpoint, so we can just exit by default.

`val_dice_score=nan` should be reproducible on main with high LR, e.g. set LR to 0.1.