### PR TITLE
Enforce that global batch size is not larger than the available dataset

### DIFF
--- a/ScaFFold/cli.py
+++ b/ScaFFold/cli.py
@@ -138,7 +138,7 @@ def main():
     )
     benchmark_parser.add_argument("--seed", type=int, help="Random seed.")
     benchmark_parser.add_argument(
-        "--batch-size", type=int, nargs="+", help="Batch sizes for each volume size."
+        "--batch-size", type=int, help="Batch sizes for each volume size."
     )
     benchmark_parser.add_argument(
         "--warmup-batches",

--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -217,6 +217,22 @@ def main(kwargs_dict: dict = {}):
         trainer.spatial_mesh = ps.device_mesh[ps.distconv_dim_names]
         num_spatial_dims = len(ps.shard_dim)
         trainer.ddp_placements = [Shard(0)] + [Replicate()] * num_spatial_dims
+        global_batch_size = config.batch_size * (
+            world_size // math.prod(config.dc_num_shards)
+        )
+        if rank == 0:
+            log.info(
+                f"Effective global batch size = {global_batch_size} "
+                f"(batch_size={config.batch_size} * "
+                f"(world_size={world_size} / prod(dc_num_shards)={math.prod(config.dc_num_shards)}))"
+            )
+        if global_batch_size > trainer.n_train:
+            raise ValueError(
+                "Effective global batch size exceeds available training samples: "
+                f"global_batch_size={global_batch_size}, n_train={trainer.n_train}, "
+                f"batch_size={config.batch_size}, world_size={world_size}, "
+                f"dc_num_shards={config.dc_num_shards}"
+            )
 
     else:
         raise RuntimeError(


### PR DESCRIPTION
Default config is 5 categories * 144 instances = 720 pairs
3 (category, instance) pairs -> 2 * n_fracts_per_vol / 2
720 / 3 = 240 total volumes/examples
180 training samples from 75/25 split

global batch size = batch_size * (world_size / prod(dc_num_shards))

So in order to ensure the same optimizer step doesn't process duplicate samples, we want global_batch_size <= training samples.

We could create a larger version of `ScaFFold/datagen/ifs_weight/weights_ins145.csv`, but adding more instances dilutes the samples, because all are variations of a single instance
```
(original) 1,1,1,1,1,1,1,1,1,1,1,1
vs
0.9,1,1,1,1,1,1,1,1,1,1,1
```

This isn't an issue in practice, because while at larger scales we need bigger `world_size` we also need more sharding, which keeps global batch size relatively low. I'm adding this check to ensure training quality is not influenced by duplicate samples.
