### PR TITLE
Improve AMP stability

### DIFF
--- a/ScaFFold/utils/data_types.py
+++ b/ScaFFold/utils/data_types.py
@@ -13,9 +13,13 @@
 # SPDX-License-Identifier: (Apache-2.0)
 
 import numpy as np
+import torch
 
 DEFAULT_NP_DTYPE = np.float64
 # Masks are values 0 <= x <= n_categories
 MASK_DTYPE = np.uint16
 # Volumes/img are 0 <= x <= 1
 VOLUME_DTYPE = np.float32
+
+# Shared AMP dtype selection for torch.autocast.
+AMP_DTYPE = torch.bfloat16

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -17,6 +17,7 @@ import torch.nn.functional as F
 from distconv import DCTensor
 from tqdm import tqdm
 
+from ScaFFold.utils.data_types import AMP_DTYPE
 from ScaFFold.utils.dice_score import (
     SpatialAllReduce,
     compute_sharded_dice,
@@ -30,6 +31,10 @@ def evaluate(
     net, dataloader, device, amp, primary, criterion, n_categories, parallel_strategy
 ):
     net.eval()
+    autocast_device_type = device.type if device.type != "mps" else "cpu"
+    autocast_kwargs = {"device_type": autocast_device_type, "enabled": amp}
+    if amp:
+        autocast_kwargs["dtype"] = AMP_DTYPE
     num_val_batches = len(dataloader)
     total_dice_score = 0.0
     processed_batches = 0
@@ -41,7 +46,7 @@ def evaluate(
             f"[eval] ps.shard_dim={parallel_strategy.shard_dim} num_shards={parallel_strategy.num_shards}"
         )
 
-    with torch.autocast(device.type if device.type != "mps" else "cpu", enabled=amp):
+    with torch.autocast(**autocast_kwargs):
         val_loss_epoch = 0.0
         for batch in tqdm(
             dataloader,
@@ -80,9 +85,7 @@ def evaluate(
                 continue
 
             # --- 1. Sharded CE Loss ---
-            with torch.autocast(
-                device.type if device.type != "mps" else "cpu", enabled=False
-            ):
+            with torch.autocast(device_type=autocast_device_type, enabled=False):
                 local_ce_sum = F.cross_entropy(
                     local_preds.float(), local_labels, reduction="sum"
                 )
@@ -100,15 +103,18 @@ def evaluate(
             CE_loss = global_ce_sum / global_total_voxels
 
             # --- 2. Format Predictions & Labels (Strictly Multiclass) ---
-            mask_pred_probs = F.softmax(local_preds, dim=1).float()
-            mask_true_onehot = (
-                F.one_hot(local_labels, n_categories + 1).permute(0, 4, 1, 2, 3).float()
-            )
+            with torch.autocast(device_type=autocast_device_type, enabled=False):
+                mask_pred_probs = F.softmax(local_preds.float(), dim=1)
+                mask_true_onehot = (
+                    F.one_hot(local_labels, n_categories + 1)
+                    .permute(0, 4, 1, 2, 3)
+                    .float()
+                )
 
-            # Dice loss uses probabilities
-            dice_score_probs = compute_sharded_dice(
-                mask_pred_probs, mask_true_onehot, spatial_mesh
-            )
+                # Dice loss uses probabilities
+                dice_score_probs = compute_sharded_dice(
+                    mask_pred_probs, mask_true_onehot, spatial_mesh
+                )
             dice_loss_curr = 1.0 - dice_score_probs.mean()
 
             # Eval metric (excluding background class 0)

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -127,7 +127,7 @@ def evaluate(
             # --- Combine and Accumulate ---
             loss = CE_loss + (1.0 - batch_dice_score)
             val_loss_epoch += loss.item()
-            total_dice_score += batch_dice_score.item()
+            total_dice_score += batch_dice_score
             processed_batches += 1
 
     net.train()

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 from distconv import DCTensor
 from tqdm import tqdm
 
-from ScaFFold.utils.data_types import AMP_DTYPE
+from ScaFFold.utils.data_types import AMP_DTYPE, VOLUME_DTYPE
 from ScaFFold.utils.dice_score import (
     SpatialAllReduce,
     compute_sharded_dice,
@@ -30,7 +30,6 @@ from ScaFFold.utils.perf_measure import annotate
 def evaluate(
     net, dataloader, device, amp, primary, criterion, n_categories, parallel_strategy
 ):
-
     def foreground_dice_mean(dice_scores):
         if dice_scores.size(1) > 1:
             return dice_scores[:, 1:].mean().item()
@@ -90,44 +89,39 @@ def evaluate(
             if local_preds.size(0) == 0 or local_labels.size(0) == 0:
                 continue
 
+            # Calculate CE and Dice loss in single precision for numerical stability.
             with torch.autocast(device_type=autocast_device_type, enabled=False):
-                # --- 1. Sharded CE Loss ---
+                # Compute global CE loss from sharded CE loss
                 local_ce_sum = F.cross_entropy(
                     local_preds.float(), local_labels, reduction="sum"
                 )
-                # --- 2. Sharded Dice Loss ---
+                global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
+                local_voxel_count = torch.tensor(
+                    float(local_labels.numel()),
+                    device=local_labels.device,
+                    dtype=VOLUME_DTYPE,
+                )
+                global_total_voxels = SpatialAllReduce.apply(
+                    local_voxel_count, spatial_mesh
+                )
+                CE_loss = global_ce_sum / global_total_voxels
+
+                # Compute global dice loss from sharded dice loss
                 mask_pred_probs = F.softmax(local_preds.float(), dim=1)
                 mask_true_onehot = (
                     F.one_hot(local_labels, n_categories + 1)
                     .permute(0, 4, 1, 2, 3)
                     .float()
                 )
-
-                # Dice loss uses probabilities
                 dice_score_probs = compute_sharded_dice(
                     mask_pred_probs, mask_true_onehot, spatial_mesh
                 )
-            global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
+                batch_dice_score = foreground_dice_mean(dice_score_probs)
 
-            # Divide by the actual global voxel count to handle uneven shards.
-            local_voxel_count = torch.tensor(
-                float(local_labels.numel()),
-                device=local_labels.device,
-                dtype=torch.float32,
-            )
-            global_total_voxels = SpatialAllReduce.apply(
-                local_voxel_count, spatial_mesh
-            )
-            CE_loss = global_ce_sum / global_total_voxels
-
-            # Eval metric (excluding background class 0)
-            # dice_score_probs shape is [Batch, Channels].
-            batch_dice_score = foreground_dice_mean(dice_score_probs)
-
-            # --- Combine and Accumulate ---
-            loss = CE_loss + (1.0 - batch_dice_score)
-            val_loss_epoch += loss.item()
-            total_dice_score += batch_dice_score
+                # Sum global CE Loss and Dice loss
+                loss = CE_loss + (1.0 - batch_dice_score)
+                val_loss_epoch += loss.item()
+                total_dice_score += batch_dice_score
             processed_batches += 1
 
     net.train()

--- a/ScaFFold/utils/evaluate.py
+++ b/ScaFFold/utils/evaluate.py
@@ -84,10 +84,22 @@ def evaluate(
             if local_preds.size(0) == 0 or local_labels.size(0) == 0:
                 continue
 
-            # --- 1. Sharded CE Loss ---
             with torch.autocast(device_type=autocast_device_type, enabled=False):
+                # --- 1. Sharded CE Loss ---
                 local_ce_sum = F.cross_entropy(
                     local_preds.float(), local_labels, reduction="sum"
+                )
+                # --- 2. Sharded Dice Loss ---
+                mask_pred_probs = F.softmax(local_preds.float(), dim=1)
+                mask_true_onehot = (
+                    F.one_hot(local_labels, n_categories + 1)
+                    .permute(0, 4, 1, 2, 3)
+                    .float()
+                )
+
+                # Dice loss uses probabilities
+                dice_score_probs = compute_sharded_dice(
+                    mask_pred_probs, mask_true_onehot, spatial_mesh
                 )
             global_ce_sum = SpatialAllReduce.apply(local_ce_sum, spatial_mesh)
 
@@ -102,19 +114,6 @@ def evaluate(
             )
             CE_loss = global_ce_sum / global_total_voxels
 
-            # --- 2. Format Predictions & Labels (Strictly Multiclass) ---
-            with torch.autocast(device_type=autocast_device_type, enabled=False):
-                mask_pred_probs = F.softmax(local_preds.float(), dim=1)
-                mask_true_onehot = (
-                    F.one_hot(local_labels, n_categories + 1)
-                    .permute(0, 4, 1, 2, 3)
-                    .float()
-                )
-
-                # Dice loss uses probabilities
-                dice_score_probs = compute_sharded_dice(
-                    mask_pred_probs, mask_true_onehot, spatial_mesh
-                )
             dice_loss_curr = 1.0 - dice_score_probs.mean()
 
             # Eval metric (excluding background class 0)

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 
 from ScaFFold.utils.checkpointing import CheckpointManager
 from ScaFFold.utils.data_loading import FractalDataset, SpatialShardSpec
-from ScaFFold.utils.data_types import AMP_DTYPE
+from ScaFFold.utils.data_types import AMP_DTYPE, VOLUME_DTYPE
 from ScaFFold.utils.dice_score import (
     SpatialAllReduce,
     compute_sharded_dice,
@@ -445,12 +445,26 @@ class PyTorchTrainer(BaseTrainer):
                     f"  warmup: Calculating sharded loss. Mem: {current_mem:.2f} GB."
                 )
 
+                # Calculate CE and Dice loss in single precision for numerical stability.
                 with torch.autocast(**self._autocast_kwargs(enabled=False)):
-                    # 1. Sharded Cross Entropy
+                    # Compute global CE loss from sharded CE loss
                     local_ce_sum = F.cross_entropy(
                         local_preds.float(), local_labels, reduction="sum"
                     )
-                    # 2. Sharded Dice Loss
+                    global_ce_sum = SpatialAllReduce.apply(
+                        local_ce_sum, self.spatial_mesh
+                    )
+                    local_voxel_count = torch.tensor(
+                        float(local_labels.numel()),
+                        device=local_labels.device,
+                        dtype=VOLUME_DTYPE,
+                    )
+                    global_total_voxels = SpatialAllReduce.apply(
+                        local_voxel_count, self.spatial_mesh
+                    )
+                    loss_ce = global_ce_sum / global_total_voxels
+
+                    # Compute global dice loss from sharded dice loss
                     local_preds_softmax = F.softmax(local_preds.float(), dim=1)
                     local_labels_one_hot = (
                         F.one_hot(
@@ -462,25 +476,10 @@ class PyTorchTrainer(BaseTrainer):
                     dice_scores = compute_sharded_dice(
                         local_preds_softmax, local_labels_one_hot, self.spatial_mesh
                     )
+                    batch_dice_score = self._foreground_dice_mean(dice_scores)
 
-                # Pass the spatial_mesh directly
-                global_ce_sum = SpatialAllReduce.apply(local_ce_sum, self.spatial_mesh)
-
-                local_voxel_count = torch.tensor(
-                    float(local_labels.numel()),
-                    device=local_labels.device,
-                    dtype=torch.float32,
-                )
-                global_total_voxels = SpatialAllReduce.apply(
-                    local_voxel_count, self.spatial_mesh
-                )
-                loss_ce = global_ce_sum / global_total_voxels
-
-                # Dice score
-                batch_dice_score = self._foreground_dice_mean(dice_scores)
-
-                # 3. Combine Loss
-                loss = loss_ce + (1.0 - batch_dice_score)
+                    # Sum global CE Loss and Dice loss
+                    loss = loss_ce + (1.0 - batch_dice_score)
 
             self.log.debug(
                 "  warmup: loss calculation complete. Proceeding to backward pass"
@@ -641,14 +640,28 @@ class PyTorchTrainer(BaseTrainer):
                                 f"Calculating sharded loss. Mem: {current_mem:.2f} GB."
                             )
 
+                            # Calculate CE and Dice loss in single precision for numerical stability.
                             with torch.autocast(**self._autocast_kwargs(enabled=False)):
-                                # 1. Sharded Cross Entropy
+                                # Compute global CE loss from sharded CE loss
                                 local_ce_sum = F.cross_entropy(
                                     local_preds.float(),
                                     local_labels,
                                     reduction="sum",
                                 )
-                                # Sharded Dice Loss
+                                global_ce_sum = SpatialAllReduce.apply(
+                                    local_ce_sum, self.spatial_mesh
+                                )
+                                local_voxel_count = torch.tensor(
+                                    float(local_labels.numel()),
+                                    device=local_labels.device,
+                                    dtype=VOLUME_DTYPE,
+                                )
+                                global_total_voxels = SpatialAllReduce.apply(
+                                    local_voxel_count, self.spatial_mesh
+                                )
+                                loss_ce = global_ce_sum / global_total_voxels
+
+                                # Compute global dice loss from sharded dice loss
                                 local_preds_softmax = F.softmax(
                                     local_preds.float(), dim=1
                                 )
@@ -660,34 +673,18 @@ class PyTorchTrainer(BaseTrainer):
                                     .permute(0, 4, 1, 2, 3)
                                     .float()
                                 )
-                                # Compute sharded dice
                                 dice_scores = compute_sharded_dice(
                                     local_preds_softmax,
                                     local_labels_one_hot,
                                     self.spatial_mesh,
                                 )
+                                batch_dice_score = self._foreground_dice_mean(
+                                    dice_scores
+                                )
 
-                            # Pass the spatial_mesh directly
-                            global_ce_sum = SpatialAllReduce.apply(
-                                local_ce_sum, self.spatial_mesh
-                            )
-
-                            local_voxel_count = torch.tensor(
-                                float(local_labels.numel()),
-                                device=local_labels.device,
-                                dtype=torch.float32,
-                            )
-                            global_total_voxels = SpatialAllReduce.apply(
-                                local_voxel_count, self.spatial_mesh
-                            )
-                            loss_ce = global_ce_sum / global_total_voxels
-
-                            # Dice score
-                            batch_dice_score = self._foreground_dice_mean(dice_scores)
-
-                            # 3. Combine Loss
-                            loss = loss_ce + (1.0 - batch_dice_score)
-                            train_dice_total += batch_dice_score.item()
+                                # Sum global CE Loss and Dice loss
+                                loss = loss_ce + (1.0 - batch_dice_score)
+                                train_dice_total += batch_dice_score.item()
 
                             end_code_region("calculate_loss")
 

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -28,8 +28,12 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from ScaFFold.utils.checkpointing import CheckpointManager
+from ScaFFold.utils.data_types import AMP_DTYPE
 from ScaFFold.utils.data_loading import FractalDataset, SpatialShardSpec
-from ScaFFold.utils.dice_score import SpatialAllReduce, compute_sharded_dice
+from ScaFFold.utils.dice_score import (
+    SpatialAllReduce,
+    compute_sharded_dice,
+)
 from ScaFFold.utils.distributed import get_local_rank, get_world_rank, get_world_size
 
 # Local
@@ -48,6 +52,9 @@ class BaseTrainer:
         self.config = config
         self.device = device
         self.log = log
+        self.amp_device_type = self.device.type if self.device.type != "mps" else "cpu"
+        self.amp_dtype = AMP_DTYPE
+        self.use_grad_scaler = False
         self.world_size = get_world_size(required=self.config.dist)
         self.world_rank = get_world_rank(required=self.config.dist)
         self.local_rank = get_local_rank(required=self.config.dist)
@@ -194,7 +201,8 @@ class BaseTrainer:
         )
 
         # Set up gradient scaler for AMP (Automatic Mixed Precision)
-        self.grad_scaler = torch.amp.GradScaler("cuda", enabled=self.config.torch_amp)
+        self.use_grad_scaler = self.config.torch_amp and self.amp_dtype == torch.float16
+        self.grad_scaler = torch.amp.GradScaler("cuda", enabled=self.use_grad_scaler)
 
         # Set up loss function
         self.criterion = (
@@ -204,8 +212,17 @@ class BaseTrainer:
         )
 
         self.log.info(
-            f"Optimizer: {self.optimizer}, Scheduler: {self.scheduler}, Gradient Scaler Enabled: {self.config.torch_amp}"
+            f"Optimizer: {self.optimizer}, Scheduler: {self.scheduler}, AMP dtype: {self.amp_dtype}, Gradient Scaler Enabled: {self.use_grad_scaler}"
         )
+
+    def _autocast_kwargs(self, enabled=None):
+        if enabled is None:
+            enabled = self.config.torch_amp
+
+        kwargs = {"device_type": self.amp_device_type, "enabled": enabled}
+        if enabled:
+            kwargs["dtype"] = self.amp_dtype
+        return kwargs
 
 
 class PyTorchTrainer(BaseTrainer):
@@ -392,10 +409,7 @@ class PyTorchTrainer(BaseTrainer):
             true_masks_dc = DCTensor.from_shard(true_masks, self.ps)
             self._get_memsize(images_dc, "Sharded image", self.config.verbose)
 
-            with torch.autocast(
-                self.device.type if self.device.type != "mps" else "cpu",
-                enabled=self.config.torch_amp,
-            ):
+            with torch.autocast(**self._autocast_kwargs()):
                 # Forward on DCTensor
                 self.log.debug("  warmup: running forward pass")
                 masks_pred_dc = self.model(images_dc)
@@ -422,10 +436,7 @@ class PyTorchTrainer(BaseTrainer):
                 )
 
                 # 1. Sharded Cross Entropy
-                with torch.autocast(
-                    self.device.type if self.device.type != "mps" else "cpu",
-                    enabled=False,
-                ):
+                with torch.autocast(**self._autocast_kwargs(enabled=False)):
                     local_ce_sum = F.cross_entropy(
                         local_preds.float(), local_labels, reduction="sum"
                     )
@@ -444,15 +455,18 @@ class PyTorchTrainer(BaseTrainer):
                 loss_ce = global_ce_sum / global_total_voxels
 
                 # 2. Sharded Dice Loss
-                local_preds_softmax = F.softmax(local_preds, dim=1).float()
-                local_labels_one_hot = (
-                    F.one_hot(local_labels, num_classes=self.config.n_categories + 1)
-                    .permute(0, 4, 1, 2, 3)
-                    .float()
-                )
-                dice_scores = compute_sharded_dice(
-                    local_preds_softmax, local_labels_one_hot, self.spatial_mesh
-                )
+                with torch.autocast(**self._autocast_kwargs(enabled=False)):
+                    local_preds_softmax = F.softmax(local_preds.float(), dim=1)
+                    local_labels_one_hot = (
+                        F.one_hot(
+                            local_labels, num_classes=self.config.n_categories + 1
+                        )
+                        .permute(0, 4, 1, 2, 3)
+                        .float()
+                    )
+                    dice_scores = compute_sharded_dice(
+                        local_preds_softmax, local_labels_one_hot, self.spatial_mesh
+                    )
                 loss_dice = 1.0 - dice_scores.mean()
 
                 # 3. Combine Loss
@@ -585,10 +599,7 @@ class PyTorchTrainer(BaseTrainer):
                             images_dc, "Sharded image", self.config.verbose
                         )
 
-                        with torch.autocast(
-                            self.device.type if self.device.type != "mps" else "cpu",
-                            enabled=self.config.torch_amp,
-                        ):
+                        with torch.autocast(**self._autocast_kwargs()):
                             # Predict on this batch
                             torch.cuda.reset_peak_memory_stats()
                             gather_and_print_mem(self.log, "pre_forward")
@@ -621,12 +632,7 @@ class PyTorchTrainer(BaseTrainer):
                             )
 
                             # 1. Sharded Cross Entropy
-                            with torch.autocast(
-                                self.device.type
-                                if self.device.type != "mps"
-                                else "cpu",
-                                enabled=False,
-                            ):
+                            with torch.autocast(**self._autocast_kwargs(enabled=False)):
                                 local_ce_sum = F.cross_entropy(
                                     local_preds.float(),
                                     local_labels,
@@ -649,22 +655,25 @@ class PyTorchTrainer(BaseTrainer):
                             loss_ce = global_ce_sum / global_total_voxels
 
                             # 2. Sharded Dice Loss
-                            local_preds_softmax = F.softmax(local_preds, dim=1).float()
-                            local_labels_one_hot = (
-                                F.one_hot(
-                                    local_labels,
-                                    num_classes=self.config.n_categories + 1,
+                            with torch.autocast(**self._autocast_kwargs(enabled=False)):
+                                local_preds_softmax = F.softmax(
+                                    local_preds.float(), dim=1
                                 )
-                                .permute(0, 4, 1, 2, 3)
-                                .float()
-                            )
+                                local_labels_one_hot = (
+                                    F.one_hot(
+                                        local_labels,
+                                        num_classes=self.config.n_categories + 1,
+                                    )
+                                    .permute(0, 4, 1, 2, 3)
+                                    .float()
+                                )
 
-                            # Compute sharded dice using new function
-                            dice_scores = compute_sharded_dice(
-                                local_preds_softmax,
-                                local_labels_one_hot,
-                                self.spatial_mesh,
-                            )
+                                # Compute sharded dice using new function
+                                dice_scores = compute_sharded_dice(
+                                    local_preds_softmax,
+                                    local_labels_one_hot,
+                                    self.spatial_mesh,
+                                )
                             loss_dice = 1.0 - dice_scores.mean()
 
                             # 3. Combine Loss

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -435,10 +435,22 @@ class PyTorchTrainer(BaseTrainer):
                     f"  warmup: Calculating sharded loss. Mem: {current_mem:.2f} GB."
                 )
 
-                # 1. Sharded Cross Entropy
                 with torch.autocast(**self._autocast_kwargs(enabled=False)):
+                    # 1. Sharded Cross Entropy
                     local_ce_sum = F.cross_entropy(
                         local_preds.float(), local_labels, reduction="sum"
+                    )
+                    # 2. Sharded Dice Loss
+                    local_preds_softmax = F.softmax(local_preds.float(), dim=1)
+                    local_labels_one_hot = (
+                        F.one_hot(
+                            local_labels, num_classes=self.config.n_categories + 1
+                        )
+                        .permute(0, 4, 1, 2, 3)
+                        .float()
+                    )
+                    dice_scores = compute_sharded_dice(
+                        local_preds_softmax, local_labels_one_hot, self.spatial_mesh
                     )
 
                 # Pass the spatial_mesh directly
@@ -454,19 +466,6 @@ class PyTorchTrainer(BaseTrainer):
                 )
                 loss_ce = global_ce_sum / global_total_voxels
 
-                # 2. Sharded Dice Loss
-                with torch.autocast(**self._autocast_kwargs(enabled=False)):
-                    local_preds_softmax = F.softmax(local_preds.float(), dim=1)
-                    local_labels_one_hot = (
-                        F.one_hot(
-                            local_labels, num_classes=self.config.n_categories + 1
-                        )
-                        .permute(0, 4, 1, 2, 3)
-                        .float()
-                    )
-                    dice_scores = compute_sharded_dice(
-                        local_preds_softmax, local_labels_one_hot, self.spatial_mesh
-                    )
                 loss_dice = 1.0 - dice_scores.mean()
 
                 # 3. Combine Loss
@@ -631,12 +630,30 @@ class PyTorchTrainer(BaseTrainer):
                                 f"Calculating sharded loss. Mem: {current_mem:.2f} GB."
                             )
 
-                            # 1. Sharded Cross Entropy
                             with torch.autocast(**self._autocast_kwargs(enabled=False)):
+                                # 1. Sharded Cross Entropy
                                 local_ce_sum = F.cross_entropy(
                                     local_preds.float(),
                                     local_labels,
                                     reduction="sum",
+                                )
+                                # Sharded Dice Loss
+                                local_preds_softmax = F.softmax(
+                                    local_preds.float(), dim=1
+                                )
+                                local_labels_one_hot = (
+                                    F.one_hot(
+                                        local_labels,
+                                        num_classes=self.config.n_categories + 1,
+                                    )
+                                    .permute(0, 4, 1, 2, 3)
+                                    .float()
+                                )
+                                # Compute sharded dice
+                                dice_scores = compute_sharded_dice(
+                                    local_preds_softmax,
+                                    local_labels_one_hot,
+                                    self.spatial_mesh,
                                 )
 
                             # Pass the spatial_mesh directly
@@ -654,26 +671,6 @@ class PyTorchTrainer(BaseTrainer):
                             )
                             loss_ce = global_ce_sum / global_total_voxels
 
-                            # 2. Sharded Dice Loss
-                            with torch.autocast(**self._autocast_kwargs(enabled=False)):
-                                local_preds_softmax = F.softmax(
-                                    local_preds.float(), dim=1
-                                )
-                                local_labels_one_hot = (
-                                    F.one_hot(
-                                        local_labels,
-                                        num_classes=self.config.n_categories + 1,
-                                    )
-                                    .permute(0, 4, 1, 2, 3)
-                                    .float()
-                                )
-
-                                # Compute sharded dice using new function
-                                dice_scores = compute_sharded_dice(
-                                    local_preds_softmax,
-                                    local_labels_one_hot,
-                                    self.spatial_mesh,
-                                )
                             loss_dice = 1.0 - dice_scores.mean()
 
                             # 3. Combine Loss

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -201,7 +201,8 @@ class BaseTrainer:
         )
 
         # Set up gradient scaler for AMP (Automatic Mixed Precision)
-        self.use_grad_scaler = self.config.torch_amp and self.amp_dtype == torch.float16
+        # bfloat does not need grad scaler
+        self.use_grad_scaler = self.config.torch_amp and self.amp_dtype != torch.bfloat16
         self.grad_scaler = torch.amp.GradScaler("cuda", enabled=self.use_grad_scaler)
 
         # Set up loss function

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -202,7 +202,9 @@ class BaseTrainer:
 
         # Set up gradient scaler for AMP (Automatic Mixed Precision)
         # bfloat does not need grad scaler
-        self.use_grad_scaler = self.config.torch_amp and self.amp_dtype != torch.bfloat16
+        self.use_grad_scaler = (
+            self.config.torch_amp and self.amp_dtype != torch.bfloat16
+        )
         self.grad_scaler = torch.amp.GradScaler("cuda", enabled=self.use_grad_scaler)
 
         # Set up loss function

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -684,7 +684,7 @@ class PyTorchTrainer(BaseTrainer):
 
                                 # Sum global CE Loss and Dice loss
                                 loss = loss_ce + (1.0 - batch_dice_score)
-                                train_dice_total += batch_dice_score.item()
+                                train_dice_total += batch_dice_score
 
                             end_code_region("calculate_loss")
 
@@ -756,7 +756,7 @@ class PyTorchTrainer(BaseTrainer):
                 #
                 # Write out data for this epoch to train stats csv
                 #
-                train_dice = float(train_dice_total / len(self.train_loader))
+                train_dice = float(train_dice_total.item() / len(self.train_loader))
                 self.log.info(
                     f" epoch {epoch} \
                             | train_dice_loss {train_dice:.6f} (type {type(train_dice)}) \

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -228,8 +228,8 @@ class BaseTrainer:
     def _foreground_dice_mean(dice_scores):
         """Match optimization to the reported validation metric by excluding background."""
         if dice_scores.size(1) > 1:
-            return dice_scores[:, 1:].mean().item()
-        return dice_scores.mean().item()
+            return dice_scores[:, 1:].mean()
+        return dice_scores.mean()
 
 
 class PyTorchTrainer(BaseTrainer):
@@ -684,7 +684,7 @@ class PyTorchTrainer(BaseTrainer):
 
                             # 3. Combine Loss
                             loss = loss_ce + (1.0 - batch_dice_score)
-                            train_dice_total += batch_dice_score
+                            train_dice_total += batch_dice_score.item()
 
                             end_code_region("calculate_loss")
 

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -28,8 +28,8 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from ScaFFold.utils.checkpointing import CheckpointManager
-from ScaFFold.utils.data_types import AMP_DTYPE
 from ScaFFold.utils.data_loading import FractalDataset, SpatialShardSpec
+from ScaFFold.utils.data_types import AMP_DTYPE
 from ScaFFold.utils.dice_score import (
     SpatialAllReduce,
     compute_sharded_dice,


### PR DESCRIPTION
- [x] Compute dice loss in FP32 to avoid `val_dice_score=nan`
- [x] Use BF16 to prevent numerical overflow.
- [x] The datatype for AMP is now centrally configurable in `ScaFFold/utils/data_types.py` for testing`.