### PR TITLE
Fix miopen cache dir handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.scaffold-miopen-cache/
 nosetests.xml
 coverage.xml
 *.cover

--- a/scripts/scaffold-tuolumne-torchpypi.job
+++ b/scripts/scaffold-tuolumne-torchpypi.job
@@ -14,6 +14,12 @@ ml cce/21.0.0 cray-mpich/9.1.0 rocm/7.1.1 rccl/fast-env-slows-mpi
 # Use ccl plugin that we manually built with install-rccl.sh
 export NCCL_NET_PLUGIN=../aws-ofi-nccl.git/install/lib/librccl-net.so
 
+# Persist MIOpen's find database and compiled-kernel cache across job submissions.
+# On Tuolumne, torchrun-hpc derives the MIOpen cache paths from TMPDIR.
+export SCAFFOLD_MIOPEN_CACHE_ROOT="${SCAFFOLD_MIOPEN_CACHE_ROOT:-$(pwd)/.scaffold-miopen-cache}"
+export TMPDIR="${SCAFFOLD_MIOPEN_TMPDIR:-${SCAFFOLD_MIOPEN_CACHE_ROOT}/tmp}"
+mkdir -p "${TMPDIR}/MIOpen_user_db" "${TMPDIR}/MIOpen_custom_cache"
+
 # Disable direct convolution benchmarking (should speedup warmup by a significant amount, does the below three options together)
 # export MIOPEN_DEBUG_CONV_DIRECT=0
 # Disable direct naive convolution benchmarking (naive_conv_ab_nonpacked_fwd_ndhwc_half_double_half.kd)

--- a/scripts/scaffold-tuolumne.job
+++ b/scripts/scaffold-tuolumne.job
@@ -15,6 +15,12 @@ ml cce/21.0.0 cray-mpich/9.1.0 rocm/7.1.1 rccl/fast-env-slows-mpi
 # (2) Removing libmpi may cause segfault on mpi4py import
 export LD_PRELOAD="/opt/rocm-7.1.1/llvm/lib/libomp.so /opt/cray/pe/mpich/9.1.0/ofi/gnu/11.2/lib/libmpi_gnu.so.12"
 
+# Persist MIOpen's find database and compiled-kernel cache across job submissions.
+# On Tuolumne, torchrun-hpc derives the MIOpen cache paths from TMPDIR.
+export SCAFFOLD_MIOPEN_CACHE_ROOT="${SCAFFOLD_MIOPEN_CACHE_ROOT:-$(pwd)/.scaffold-miopen-cache}"
+export TMPDIR="${SCAFFOLD_MIOPEN_TMPDIR:-${SCAFFOLD_MIOPEN_CACHE_ROOT}/tmp}"
+mkdir -p "${TMPDIR}/MIOpen_user_db" "${TMPDIR}/MIOpen_custom_cache"
+
 # Disable direct convolution benchmarking (should speedup warmup by a significant amount, does the below three options together)
 # export MIOPEN_DEBUG_CONV_DIRECT=0
 # Disable direct naive convolution benchmarking (naive_conv_ab_nonpacked_fwd_ndhwc_half_double_half.kd)


### PR DESCRIPTION
`torchrun-hpc` uses TMPDIR to set MIOpen cache dirs, regardless of how we set those dirs outside of `torchrun-hpc` calls. This PR modifies the Tuolumne run scripts to set TMPDIR to a persistent location, allowing MIOpen to actually reuse cached kernel benchmarking results across runs. At scale 7, this improves warmup speed on all runs after the first by ~25%.