### PR TITLE
Update hpc-launcher version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ authors = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-  "hpc-launcher>=1.0.4",
+  "hpc-launcher @ git+https://github.com/LBANN/HPC-launcher.git@bba5e32",
   "matplotlib>=3.9.4",
   "numpy>=1.26.4",
   "numba>=0.60.0",


### PR DESCRIPTION
This is mostly for [4a5c36ef652351761c77509dbe6305ce0bfa7444](https://github.com/LBANN/HPC-launcher/pull/60), because if multiple jobs are started within the same second the will share a directory, which is bad behavior. This is happening when I am submitting many jobs at the same time for the scaling runs.