### PR TITLE
Add group_norm_groups as FOM-specific parameter

### DIFF
--- a/ScaFFold/worker.py
+++ b/ScaFFold/worker.py
@@ -289,6 +289,7 @@ def main(kwargs_dict: dict = {}):
         log.info(
             f"FOM = {fom} (1 / total_train_time={total_train_time:.6f} seconds). "
             f"This FOM is specific to problem_scale={config.problem_scale}, "
+            f"group_norm_groups={config.group_norm_groups}, "
             f"target_dice={config.target_dice}, seed={config.seed}."
         )
         epochs = np.atleast_1d(train_data["epoch"])


### PR DESCRIPTION
This parameter will affect convergence. 

@PatrickRMiles I'm thinking if there is a better way to do this. Should we list a bunch of parameters here like n_categories, n_instances_used_per_fractal, unet_bottleneck_dim or just print the entire config? sharding? We already have variables listed under `# Internal/dev use only` in the default config, so maybe those can be assumed to impact FOM