### PR TITLE
Bump DistConv version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "tqdm>=4.67.1",
   "wandb>=0.19.6",
   "PyYAML>=6.0.2",
-  "distconv @ git+https://github.com/LBANN/DistConv.git@232cba6",
+  "distconv @ git+https://github.com/LBANN/DistConv.git@084b20a",
 ]
 requires-python = ">=3.9"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ tqdm>=4.67.1
 wandb>=0.19.6
 PyYAML>=6.0.2
 mpi4py==4.1.1 --no-binary mpi4py
-distconv @ git+https://github.com/LBANN/DistConv.git@232cba6
+distconv @ git+https://github.com/LBANN/DistConv.git@084b20a


### PR DESCRIPTION
The new version contains a significant memory leak fix. Since we run into oom issues, this may help us.

I've tested ScaFFold with the new version to check for any unexpected failures.