### PR TITLE
Check for checkpoints

### DIFF
--- a/ScaFFold/cli.py
+++ b/ScaFFold/cli.py
@@ -302,6 +302,25 @@ def main():
 
     comm.Barrier()
     combined_config = comm.bcast(combined_config, root=0)
+
+    if combined_config.get("restart", False):
+        run_dir = combined_config.get("run_dir")
+        if not run_dir:
+            raise ValueError("--restart requires --run-dir")
+
+        checkpoint_dir = Path(run_dir) / combined_config.get(
+            "checkpoint_dir", "checkpoints"
+        )
+        expected_checkpoints = (
+            checkpoint_dir / "checkpoint_last.pth",
+            checkpoint_dir / "checkpoint_best.pth",
+        )
+        if not any(path.exists() for path in expected_checkpoints):
+            expected = " or ".join(str(path) for path in expected_checkpoints)
+            raise FileNotFoundError(
+                f"Restart requested but no checkpoint was found. Expected {expected}."
+            )
+
     if rank == 0:
         print(f"combined_config = {combined_config}")
 

--- a/ScaFFold/utils/checkpointing.py
+++ b/ScaFFold/utils/checkpointing.py
@@ -145,7 +145,7 @@ class CheckpointManager:
         if self.optimizer:
             self.optimizer.zero_grad(set_to_none=True)
 
-    def load_from_checkpoint(self) -> int:
+    def load_from_checkpoint(self, require_checkpoint: bool = False) -> int:
         """Load the latest checkpoint. Returns start_epoch (default 1)."""
         self.wait_for_save()  # Safety: don't load while writing
 
@@ -159,6 +159,11 @@ class CheckpointManager:
 
         candidate = self._broadcast_obj(candidate)
         if not candidate:
+            if require_checkpoint:
+                raise FileNotFoundError(
+                    "Restart requested but no checkpoint was found. "
+                    f"Expected {self.last_ckpt_path} or {self.best_ckpt_path}."
+                )
             return 1
 
         self._log(f"Loading checkpoint from {candidate}")

--- a/ScaFFold/utils/checkpointing.py
+++ b/ScaFFold/utils/checkpointing.py
@@ -145,7 +145,7 @@ class CheckpointManager:
         if self.optimizer:
             self.optimizer.zero_grad(set_to_none=True)
 
-    def load_from_checkpoint(self, require_checkpoint: bool = False) -> int:
+    def load_from_checkpoint(self) -> int:
         """Load the latest checkpoint. Returns start_epoch (default 1)."""
         self.wait_for_save()  # Safety: don't load while writing
 
@@ -159,12 +159,10 @@ class CheckpointManager:
 
         candidate = self._broadcast_obj(candidate)
         if not candidate:
-            if require_checkpoint:
-                raise FileNotFoundError(
-                    "Restart requested but no checkpoint was found. "
-                    f"Expected {self.last_ckpt_path} or {self.best_ckpt_path}."
-                )
-            return 1
+            raise FileNotFoundError(
+                "Restart requested but no checkpoint was found. "
+                f"Expected {self.last_ckpt_path} or {self.best_ckpt_path}."
+            )
 
         self._log(f"Loading checkpoint from {candidate}")
 

--- a/ScaFFold/utils/config_utils.py
+++ b/ScaFFold/utils/config_utils.py
@@ -60,6 +60,7 @@ class Config:
         self.more_determinism = bool(config_dict["more_determinism"])
         self.datagen_from_scratch = bool(config_dict["datagen_from_scratch"])
         self.train_from_scratch = bool(config_dict["train_from_scratch"])
+        self.restart = bool(config_dict.get("restart", False))
         self.val_split = config_dict["val_split"]
         self.seed = config_dict["seed"]
         self.dist = bool(config_dict["dist"])

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -318,9 +318,7 @@ class PyTorchTrainer(BaseTrainer):
             self.start_epoch = 1
         else:
             # Load checkpoint via manager
-            self.start_epoch = self.checkpoint_manager.load_from_checkpoint(
-                require_checkpoint=getattr(self.config, "restart", False)
-            )
+            self.start_epoch = self.checkpoint_manager.load_from_checkpoint()
 
             # Restore extra metadata if needed (e.g. mask values)
             if "train_mask_values" in self.checkpoint_manager.restored_extras:

--- a/ScaFFold/utils/trainer.py
+++ b/ScaFFold/utils/trainer.py
@@ -318,7 +318,9 @@ class PyTorchTrainer(BaseTrainer):
             self.start_epoch = 1
         else:
             # Load checkpoint via manager
-            self.start_epoch = self.checkpoint_manager.load_from_checkpoint()
+            self.start_epoch = self.checkpoint_manager.load_from_checkpoint(
+                require_checkpoint=getattr(self.config, "restart", False)
+            )
 
             # Restore extra metadata if needed (e.g. mask values)
             if "train_mask_values" in self.checkpoint_manager.restored_extras:


### PR DESCRIPTION
I have been using checkpoints via
```
--restart \
  --run-dir /usr/workspace/mckinsey/ScaFFold-RFP/scaling/tuolumne/torchrun_hpc-scaffold_2026-06-23_06h34m11s_380741e8/benchmark_runs/benchmark_20260623-063806
```

and I noticed if an incorrect path is specified, e.g. if scaffold can't find a checkpoint, it will start from scratch. This led to me accidentally restarting the same jobs. I think we should check for the checkpoint file first and exit if the user made a mistake, instead of starting from the beginning and wasting compute cycles.