### PR TITLE
Update CUDA install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ test = [
   "psutil",
 ]
 cuda = [
-    "torch==2.10.0+cu129",
+    "torch==2.12.0+cu132",
     "mpi4py==4.1.1",
 ]
 rocm = [

--- a/scripts/install-matrix.sh
+++ b/scripts/install-matrix.sh
@@ -1,4 +1,4 @@
-ml load python/3.11.5 && python3 -m venv .venvs/scaffoldvenv-matrix && source .venvs/scaffoldvenv-matrix/bin/activate && pip install --upgrade pip
-ml cuda/12.9.1 gcc/13.3.1 mvapich2/2.3.7
+ml load python/3.13.2 && python3 -m venv .venvs/scaffoldvenv-matrix && source .venvs/scaffoldvenv-matrix/bin/activate && pip install --upgrade pip
+ml cuda/13.1.1 gcc/13.3.1 mvapich2/2.3.7
 export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
-pip install --no-binary=mpi4py -e .[cuda] --prefix=.venvs/scaffoldvenv-matrix --extra-index-url https://download.pytorch.org/whl/cu129 2>&1 | tee install.log
+pip install --no-binary=mpi4py -e .[cuda] --prefix=.venvs/scaffoldvenv-matrix --extra-index-url https://download.pytorch.org/whl/cu132 2>&1 | tee install.log


### PR DESCRIPTION
- [x] CUDA/12 -> CUDA/13
- [x] torch2.10 -> torch2.12
- [x] python/3.11 -> python/3.13

The wheel with these versions is 1-2% faster on one node. So not critical, but no regression.